### PR TITLE
cairo program hash

### DIFF
--- a/lib/cairo.ex
+++ b/lib/cairo.ex
@@ -73,4 +73,9 @@ defmodule Cairo do
   defdelegate poseidon_many(inputs),
     to: Cairo.CairoProver,
     as: :poseidon_many
+
+  @spec get_program_hash(list(byte())) :: list(byte())
+  defdelegate get_program_hash(pub_input),
+    to: Cairo.CairoProver,
+    as: :program_hash
 end

--- a/lib/cairo/cairo.ex
+++ b/lib/cairo/cairo.ex
@@ -40,6 +40,9 @@ defmodule Cairo.CairoProver do
 
   def poseidon_many(_inputs),
     do: :erlang.nif_error(:nif_not_loaded)
+
+  def program_hash(_public_inputs),
+    do: :erlang.nif_error(:nif_not_loaded)
 end
 
 defmodule Cairo.CairoVM do

--- a/test/cairo_test.exs
+++ b/test/cairo_test.exs
@@ -19,5 +19,8 @@ defmodule NifTest do
     # Prove and verify
     {proof, public_input} = Cairo.prove(trace, memory, vm_public_input)
     assert true = Cairo.verify(proof, public_input)
+
+    # Get program hash
+    _program_hash = Cairo.get_program_hash(public_input)
   end
 end


### PR DESCRIPTION
The cairo program hash will be used as the resource label in Anoma RM.