### PR TITLE
bump lambdaworks

### DIFF
--- a/native/cairo_prover/Cargo.toml
+++ b/native/cairo_prover/Cargo.toml
@@ -11,9 +11,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = "0.31.0"
-cairo-platinum-prover = { git = "https://github.com/lambdaclass/lambdaworks", version = "0.7.0"}
-stark-platinum-prover = { git = "https://github.com/lambdaclass/lambdaworks", version = "0.7.0"}
-lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks", version = "0.7.0"}
+cairo-platinum-prover = { git = "https://github.com/lambdaclass/lambdaworks", version = "0.8.0"}
+stark-platinum-prover = { git = "https://github.com/lambdaclass/lambdaworks", version = "0.8.0"}
+lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks", version = "0.8.0"}
 bincode = "2.0.0-rc.3"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 hashbrown = { version = "0.14.0", features = ["serde"] }


### PR DESCRIPTION
The aarm_cairo doesn't compile when lambdaworks released version 0.8.0, even though we explicitly specified the dependency on lambdaworks version `0.7.0` in aarm_cairo. It's annoying that we have to update to the latest version `0.8.0`. 

It seems some sub-libraries of lambdaworks don't specify proper dependency versions and only require the latest ones, so the dependencies are forced to update.